### PR TITLE
feat: Add delete functionality for cancelled orders for admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,7 +30,8 @@ service cloud.firestore {
     
     // Data pesanan
     match /orders/{orderId} {
-    	allow read, write: if isAuth();
+      allow read, create, update: if isAuth();
+      allow delete: if false; // Deletion must be done via cloud function
     }
     match /orderCounters/{counterId} {
     	allow read, write: if isAuth();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -90,6 +90,35 @@
             </div>
         </div>
 
+        <!-- Modal Konfirmasi Hapus Pesanan -->
+        <div class="modal fade" id="delete-confirm-modal" tabindex="-1" aria-labelledby="deleteConfirmModalLabel"
+            aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="deleteConfirmModalLabel">Konfirmasi Hapus Pesanan</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>Anda akan menghapus pesanan <strong id="delete-modal-order-id"></strong> secara permanen.
+                            Tindakan ini tidak dapat dibatalkan.</p>
+                        <p>Untuk melanjutkan, ketik ulang nomor pesanan di bawah ini.</p>
+                        <div class="mb-3">
+                            <input type="text" class="form-control" id="delete-modal-confirm-input"
+                                placeholder="Ketik nomor pesanan di sini...">
+                            <div class="form-text">Tombol "Ya, Hapus Permanen" akan aktif jika nomor pesanan sesuai.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Batal</button>
+                        <button type="button" class="btn btn-danger" id="confirm-delete-btn" disabled>Ya, Hapus
+                            Permanen</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
 
     </main>
 


### PR DESCRIPTION
This commit introduces the ability for administrators to permanently delete orders that have a 'cancelled' status.

- Adds a new `deleteCancelledOrder` Cloud Function that verifies the user is an admin and the order status is 'cancelled' before deleting.
- Updates the dashboard to display a 'Delete Permanen' button in the actions dropdown for cancelled orders, visible only to admins.
- Implements a confirmation modal, requiring the admin to type the order ID to prevent accidental deletion.
- Strengthens Firestore security rules to prevent direct client-side deletions, ensuring all delete operations are processed through the secure Cloud Function.