### PR TITLE
feat: add user hierarchy page and ancestor tracking

### DIFF
--- a/public/js/user-hierarchy.js
+++ b/public/js/user-hierarchy.js
@@ -1,0 +1,67 @@
+// public/js/user-hierarchy.js
+
+import { auth, functions } from './firebase-config.js';
+import { httpsCallable } from "https://www.gstatic.com/firebasejs/9.19.1/firebase-functions.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.19.1/firebase-auth.js";
+
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('user-tree-container');
+    const listAllUsers = httpsCallable(functions, 'listAllUsers');
+
+    function buildUserTree(users) {
+        const map = {};
+        users.forEach(u => { map[u.uid] = { ...u, children: [] }; });
+        const roots = [];
+        users.forEach(u => {
+            if (u.representativeId && map[u.representativeId]) {
+                map[u.representativeId].children.push(map[u.uid]);
+            } else {
+                roots.push(map[u.uid]);
+            }
+        });
+        return roots;
+    }
+
+    function renderUserTree(nodes) {
+        const ul = document.createElement('ul');
+        ul.className = 'list-unstyled';
+        nodes.forEach(node => {
+            const li = document.createElement('li');
+            li.textContent = `${node.email} (${node.role})`;
+            if (node.children.length > 0) {
+                const child = renderUserTree(node.children);
+                child.classList.add('ms-4');
+                li.appendChild(child);
+            }
+            ul.appendChild(li);
+        });
+        return ul;
+    }
+
+    async function loadUsers() {
+        container.innerHTML = '<p>Memuat...</p>';
+        try {
+            const result = await listAllUsers();
+            const users = result.data;
+            const tree = buildUserTree(users);
+            container.innerHTML = '';
+            container.appendChild(renderUserTree(tree));
+        } catch (error) {
+            console.error('Gagal mengambil data pengguna:', error);
+            container.innerHTML = '<p class="text-danger">Gagal memuat data pengguna.</p>';
+        }
+    }
+
+    onAuthStateChanged(auth, async (user) => {
+        if (user) {
+            const token = await user.getIdTokenResult(true);
+            if (token.claims.role === 'admin') {
+                loadUsers();
+            } else {
+                container.innerHTML = '<p class="text-danger">Akses ditolak.</p>';
+            }
+        } else {
+            container.innerHTML = '<p>Anda harus login.</p>';
+        }
+    });
+});

--- a/public/user-hierarchy.html
+++ b/public/user-hierarchy.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="id">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hierarki Pengguna - Sistem Order Pulazzz</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="css/style.css" rel="stylesheet">
+</head>
+
+<body>
+
+    <nav id="main-header" class="navbar navbar-dark header-bg shadow-sm sticky-top">
+        <div class="container">
+            <a class="navbar-brand d-flex align-items-center" href="#">
+                <img src="/assets/logo-pulazzz-putih.png" alt="Logo Pulazzz" class="header-logo me-2">
+                <span class="d-none d-sm-inline">Order System</span>
+            </a>
+            <div class="d-flex">
+                <div class="spinner-border spinner-border-sm text-light" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container mt-5 main-container-limited">
+        <h2 class="mb-4">Hierarki Pengguna</h2>
+        <div id="user-tree-container">
+            <p>Memuat...</p>
+        </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script type="module" src="js/firebase-config.js"></script>
+    <script type="module" src="js/auth-guard.js"></script>
+    <script type="module" src="js/navigation.js"></script>
+    <script type="module" src="js/user-hierarchy.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add `ancestors` materialized path in user profile creation and role updates
- extend `listAllUsers` to merge authentication and profile data
- introduce user hierarchy page rendering nested structure

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd functions && npm test)` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa30c8683c8328b6c5c68caf995275